### PR TITLE
PC - use a relative import for f2py sgp4_ in sgp4.py

### DIFF
--- a/src/pyobs/sgp4.py
+++ b/src/pyobs/sgp4.py
@@ -4,7 +4,7 @@
 
 """
 
-import sgp4_
+from . import sgp4_
 
 from datetime import datetime, timedelta
 from numpy import sin, cos, pi, arccos, dot, sqrt, array


### PR DESCRIPTION
this is a fix to sgp4.py for importing sgp4_.  Needs a relative import statement.