### PR TITLE
Feature/pcolarco/wavelength bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *sampler* module 
 - trj_sample command line utility rewritten in terms of the new 
   *sampler* module 
-  - module *icartt* extebded with to_xarray() method. 
+  - module *icartt* extebded with to_xarray() method.
+  - mietables.py wavelength bug fix (nm to m unit conversion)
 
 ### Fixed 
 

--- a/src/pyobs/mietable.py
+++ b/src/pyobs/mietable.py
@@ -144,13 +144,13 @@ class MIETABLE(object):
 
       if wavelength is not None:
           wavelength_ = wavelength / 1e9 # User species nm, tables use m
-          
+
       bin_ = bin - 1
       if 'wavelength' in self.ds[name].dims:
          assert wavelength_ is not None, \
                 'wavelength should be provided to get variable ' \
                 + name + ' in file ' + filename
-         wavelength_ = min(max(wavelength, self.min_wavelength), self.max_wavelength)
+         wavelength_ = min(max(wavelength_, self.min_wavelength), self.max_wavelength)
          da = self.ds[name].isel({'bin':[bin_]}).interp({'wavelength': [wavelength_]})
       else:
          da = self.ds[name].isel({'bin':[bin_]})


### PR DESCRIPTION
There was a bug in the _getAOP function where the comparison wavelength was not properly scaled from nm to meters to compare to the table wavelength boundaries, resulting in selecting only max wavelength values from the table.