### PR TITLE
Fix/pcastell/speciated aop dividebyzero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - aop.py *getAOPrt* phase function now being correctly normalized 
   by total scattering
 
+- aop.py - protect against divide by zero in getAOPrt and getAOPext when doing calculation for an individual species
+
+- aop.py - remove dependency on having 'DU' as a species in your yaml optics table definition
 ### Removed 
 
 # [v1.1.0] 2024-03-20

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -139,9 +139,11 @@ class G2GAOP(object):
 
         # Check consistency of Mie tables accross species
         # -----------------------------------------------
-        dims =  self.mieTable['DU']['mie'].getDims()
+        # start with last species read
+        dims =  self.mieTable[s]['mie'].getDims()
         self.vector = True
         self.p, self.m = (0,0)
+        # loop through species and compare dims
         for s in self.mieTable:
            dims_ = self.mieTable[s]['mie'].getDims() # dimensions of Mie Tables, a dict
            if dims_['p'] is None:

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -249,13 +249,26 @@ class G2GAOP(object):
                 bin += 1
 
         # Final normalization of SSA and g
+        # protect against divide by zero
+        # this can happen if you ask for the AOP of an individual species
+        # and its' concentration in a layer is zero        
         # --------------------------------
-        ssa = sca / aot
+        ssa = np.empty(space)
+        ssa[:] = np.nan
+        I = np.where(aot != 0.0)
+        ssa[I] = sca[I] / aot[I]
+
         if vector:
-             pmom = pmom / sca.reshape((ns,1,1))
+             I = np.where(sca.reshape((ns) != 0.0))[0]
+             pmom[I,:,:] = pmom[I,:,:] / sca.reshape((ns,1,1))[I,:,:]
+             I = np.where(sca.reshape((ns) == 0.0))[0]
+             pmom[I,:,:] = np.nan
              pmom = pmom.reshape(space+(p,m))
         else:
-             g = g / sca
+             I = np.where(sca != 0.0)
+             g[I] = g[I] / sca[I]
+             I = np.where(sca == 0.0)
+             g[I] = np.nan
 
 
         A = dict (AOT = {'long_name':'Aerosol Optical Thickness', 'units':'1'},
@@ -368,7 +381,15 @@ class G2GAOP(object):
         ext *= 1000. # m-1 to km-1
         sca *= 1000. # m-1 to km-1
         bsc *= 1000. # m-1 to km-1
-        depol = depol1 / depol2
+
+        # protect against divide by zero
+        # this can happen if you ask for the AOP of an individual species
+        # and its' concentration in a layer is zero
+        # -----------------------------------------
+        depol = np.empty(space)
+        depol[:] = np.nan
+        I = np.where(depol2 != 0.0)
+        depol[I] = depol1[I] / depol2[I]
 
         # Attributes
         # ----------


### PR DESCRIPTION
Addresses issue #52 and #50 

Protect against divide by zero in AOP calculator for an individual species.
Remove dependency on having 'DU' as a species in your yaml definition of the optics tables.