### PR TITLE
PM2.5 Calculation in Differing GEOS Configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+# [Unreleased] 2024-08-19 Modified by A.Collow
+### Added
+
+### Changed
+
+### Fixed
+-missing conversion from the sulfate ion to ammonium sulfate
 
 # [Unreleased] 2024-04-19 Modified by A.Collow
 
@@ -12,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 
 
 ### Fixed 
-
+-
 - aop.py *getAOPrt* phase function now being correctly normalized 
   by total scattering
 

--- a/src/config/g2g_pm25.yaml
+++ b/src/config/g2g_pm25.yaml
@@ -1,4 +1,4 @@
-# 
+#
 # GEOS Aerosol Mie table Definition for each of species.
 # This example is for calculating PM2.5 concentrations for a nominal GOCART-2G Model Configuration.
 # Note that the two largest Nitrate bins should not be included in the calculation of PM2.5.
@@ -11,7 +11,7 @@
 #               GMAO Office Note No. 22 (Version 1.1):
 #               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
-#   pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2.  
+#   pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2.
 #                 For a nominal GOCART-2G simulation pmconversion = 1 for all species.
 
 DU:

--- a/src/config/g2g_pm25.yaml
+++ b/src/config/g2g_pm25.yaml
@@ -113,5 +113,3 @@ NH4:
   rhod:
     - 1725
   pmconversion: 1
-
-

--- a/src/config/g2g_pm25.yaml
+++ b/src/config/g2g_pm25.yaml
@@ -1,0 +1,117 @@
+#
+# GEOS Aerosol Mie table Definition for each of species.
+# The order of the tracers and rhod correspond to the bins in the optics netcdf files.
+#
+#  rhod: particle density in kg m-3
+#  shapefactor: factor that accounts for aerodynamic resistance of non-spherical particles
+#               this is used to calculate the aerodynamic radius for PM calculations when the aerodymic flag is turned on
+#               see the following reference for further documentation
+#               GMAO Office Note No. 22 (Version 1.1): 
+#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
+#               Supplemental Documentation for GEOS Aerosol Products
+
+DU:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v15_3.RRTMG.nc4
+  tracers:
+    - DU001
+    - DU002
+    - DU003
+    - DU004
+    - DU005
+  shapefactor: 1.4
+  rhod:
+    - 2500
+    - 2650
+    - 2650
+    - 2650
+    - 2650
+  pmconversion: 1
+
+
+SS:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SS.v3_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SS.v3_3.RRTMG.nc4
+  tracers:
+    - SS001
+    - SS002
+    - SS003
+    - SS004
+    - SS005
+  shapefactor: 1
+  rhod:
+    - 2200
+    - 2200
+    - 2200
+    - 2200
+    - 2200
+  pmconversion: 1
+
+
+OC:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_OC.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_OC.v1_3.RRTMG.nc4
+  tracers:
+    - OCPHOBIC
+    - OCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+BC:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BC.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BC.v1_3.RRTMG.nc4
+  tracers:
+    - BCPHOBIC
+    - BCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+BR:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_5.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_5.RRTMG.nc4
+  tracers:
+    - BRPHOBIC
+    - BRPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+SU:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_3.RRTMG.nc4
+  tracers:
+    - SO4
+  shapefactor: 1
+  rhod:
+    - 1700
+  pmconversion: 1
+
+NI:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
+  tracers:
+    - NI001
+  shapefactor: 1
+  rhod:
+    - 1725
+  pmconversion: 1
+
+NH4:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
+  tracers:
+    - NH4a
+  shapefactor: 1
+  rhod:
+    - 1725
+  pmconversion: 1
+
+

--- a/src/config/g2g_pm25.yaml
+++ b/src/config/g2g_pm25.yaml
@@ -1,5 +1,7 @@
-#
+# 
 # GEOS Aerosol Mie table Definition for each of species.
+# This example is for calculating PM2.5 concentrations for a nominal GOCART-2G Model Configuration.
+# Note that the two largest Nitrate bins should not be included in the calculation of PM2.5.
 # The order of the tracers and rhod correspond to the bins in the optics netcdf files.
 #
 #  rhod: particle density in kg m-3
@@ -9,6 +11,8 @@
 #               GMAO Office Note No. 22 (Version 1.1):
 #               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
+#   pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2.  
+#                 For a nominal GOCART-2G simulation pmconversion = 1 for all species.
 
 DU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4

--- a/src/config/g2g_pm25.yaml
+++ b/src/config/g2g_pm25.yaml
@@ -6,8 +6,8 @@
 #  shapefactor: factor that accounts for aerodynamic resistance of non-spherical particles
 #               this is used to calculate the aerodynamic radius for PM calculations when the aerodymic flag is turned on
 #               see the following reference for further documentation
-#               GMAO Office Note No. 22 (Version 1.1): 
-#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
+#               GMAO Office Note No. 22 (Version 1.1):
+#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
 
 DU:

--- a/src/config/geos529_pm25.yaml
+++ b/src/config/geos529_pm25.yaml
@@ -1,0 +1,105 @@
+#
+# GEOS Aerosol Mie table Definition for each of species.
+# The order of the tracers and rhod correspond to the bins in the optics netcdf files.
+#
+#  rhod: particle density in kg m-3
+#  shapefactor: factor that accounts for aerodynamic resistance of non-spherical particles
+#               this is used to calculate the aerodynamic radius for PM calculations when the aerodymic flag is turned on
+#               see the following reference for further documentation
+#               GMAO Office Note No. 22 (Version 1.1): 
+#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
+#               Supplemental Documentation for GEOS Aerosol Products
+
+DU:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v15_3.RRTMG.nc4
+  tracers:
+    - DU001
+    - DU002
+    - DU003
+    - DU004
+    - DU005
+  shapefactor: 1.4
+  rhod:
+    - 2500
+    - 2650
+    - 2650
+    - 2650
+    - 2650
+  pmconversion: 1
+
+
+SS:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SS.v3_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SS.v3_3.RRTMG.nc4
+  tracers:
+    - SS001
+    - SS002
+    - SS003
+    - SS004
+    - SS005
+  shapefactor: 1
+  rhod:
+    - 2200
+    - 2200
+    - 2200
+    - 2200
+    - 2200
+  pmconversion: 1
+
+
+OC:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_OC.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_OC.v1_3.RRTMG.nc4
+  tracers:
+    - OCPHOBIC
+    - OCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+BC:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BC.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BC.v1_3.RRTMG.nc4
+  tracers:
+    - BCPHOBIC
+    - BCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+SU:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_3.RRTMG.nc4
+  tracers:
+    - SO4
+  shapefactor: 1
+  rhod:
+    - 1700
+  pmconversion: 1
+
+NI:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
+  tracers:
+    - NO3AN1
+  shapefactor: 1
+  rhod:
+    - 1725
+  pmconversion: 1
+
+NH4:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
+  tracers:
+    - NH4A
+  shapefactor: 1
+  rhod:
+    - 1725
+  pmconversion: 1
+
+

--- a/src/config/geos529_pm25.yaml
+++ b/src/config/geos529_pm25.yaml
@@ -6,8 +6,8 @@
 #  shapefactor: factor that accounts for aerodynamic resistance of non-spherical particles
 #               this is used to calculate the aerodynamic radius for PM calculations when the aerodymic flag is turned on
 #               see the following reference for further documentation
-#               GMAO Office Note No. 22 (Version 1.1): 
-#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
+#               GMAO Office Note No. 22 (Version 1.1):
+#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
 
 DU:

--- a/src/config/geos529_pm25.yaml
+++ b/src/config/geos529_pm25.yaml
@@ -28,7 +28,6 @@ DU:
     - 2650
   pmconversion: 1
 
-
 SS:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SS.v3_3.nc4
   bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SS.v3_3.RRTMG.nc4
@@ -101,5 +100,3 @@ NH4:
   rhod:
     - 1725
   pmconversion: 1
-
-

--- a/src/config/geos529_pm25.yaml
+++ b/src/config/geos529_pm25.yaml
@@ -1,5 +1,7 @@
 #
 # GEOS Aerosol Mie table Definition for each of species.
+# This example is for calculating PM2.5 concentrations for the current (Aug 2024) forward processing system (GEOS-FP v529).
+# Note that the two largest Nitrate bins should not be included in the calculation of PM2.5, and Brown Carbon is not included in this system version.
 # The order of the tracers and rhod correspond to the bins in the optics netcdf files.
 #
 #  rhod: particle density in kg m-3
@@ -9,6 +11,8 @@
 #               GMAO Office Note No. 22 (Version 1.1):
 #               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
+#   pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2.
+#                 As nitrate is included in this simulation pmconversion = 1 for all species.
 
 DU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4

--- a/src/config/m2_pm25.yaml
+++ b/src/config/m2_pm25.yaml
@@ -11,8 +11,8 @@
 #               GMAO Office Note No. 22 (Version 1.1):
 #               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
-#  pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2. 
-#                pmconversion = 1.3756 for Sulfate 
+#  pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2.
+#                pmconversion = 1.3756 for Sulfate
 
 DU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v14_2.nc4

--- a/src/config/m2_pm25.yaml
+++ b/src/config/m2_pm25.yaml
@@ -6,8 +6,8 @@
 #  shapefactor: factor that accounts for aerodynamic resistance of non-spherical particles
 #               this is used to calculate the aerodynamic radius for PM calculations when the aerodymic flag is turned on
 #               see the following reference for further documentation
-#               GMAO Office Note No. 22 (Version 1.1): 
-#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
+#               GMAO Office Note No. 22 (Version 1.1):
+#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
 #  pmconversion: a conversion factor of 1.3756 is used to convert the sulfate ion to ammonium nitrate
 

--- a/src/config/m2_pm25.yaml
+++ b/src/config/m2_pm25.yaml
@@ -1,5 +1,7 @@
 #
 # GEOS Aerosol Mie table Definition for each of species.
+# This example is for calculating PM2.5 concentrations for the MERRA-2 GEOS configuration.
+# Note that Nitrate and Brown Carbon are not included in this system.
 # The order of the tracers and rhod correspond to the bins in the optics netcdf files.
 #
 #  rhod: particle density in kg m-3
@@ -9,7 +11,8 @@
 #               GMAO Office Note No. 22 (Version 1.1):
 #               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023.
 #               Supplemental Documentation for GEOS Aerosol Products
-#  pmconversion: a conversion factor of 1.3756 is used to convert the sulfate ion to ammonium nitrate
+#  pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2. 
+#                pmconversion = 1.3756 for Sulfate 
 
 DU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v14_2.nc4

--- a/src/config/m2_pm25.yaml
+++ b/src/config/m2_pm25.yaml
@@ -12,8 +12,8 @@
 #  pmconversion: a conversion factor of 1.3756 is used to convert the sulfate ion to ammonium nitrate
 
 DU:
-  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4
-  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v15_3.RRTMG.nc4
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v14_2.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v14_2.RRTMG.nc4
   tracers:
     - DU001
     - DU002

--- a/src/config/m2_pm25.yaml
+++ b/src/config/m2_pm25.yaml
@@ -82,4 +82,3 @@ SU:
   rhod:
     - 1700
   pmconversion: 1.3756
-

--- a/src/config/m2_pm25.yaml
+++ b/src/config/m2_pm25.yaml
@@ -1,0 +1,85 @@
+#
+# GEOS Aerosol Mie table Definition for each of species.
+# The order of the tracers and rhod correspond to the bins in the optics netcdf files.
+#
+#  rhod: particle density in kg m-3
+#  shapefactor: factor that accounts for aerodynamic resistance of non-spherical particles
+#               this is used to calculate the aerodynamic radius for PM calculations when the aerodymic flag is turned on
+#               see the following reference for further documentation
+#               GMAO Office Note No. 22 (Version 1.1): 
+#               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
+#               Supplemental Documentation for GEOS Aerosol Products
+#  pmconversion: a conversion factor of 1.3756 is used to convert the sulfate ion to ammonium nitrate
+
+DU:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_DU.v15_3.RRTMG.nc4
+  tracers:
+    - DU001
+    - DU002
+    - DU003
+    - DU004
+    - DU005
+  shapefactor: 1.4
+  rhod:
+    - 2500
+    - 2650
+    - 2650
+    - 2650
+    - 2650
+  pmconversion: 1
+
+
+SS:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SS.v3_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SS.v3_3.RRTMG.nc4
+  tracers:
+    - SS001
+    - SS002
+    - SS003
+    - SS004
+    - SS005
+  shapefactor: 1
+  rhod:
+    - 2200
+    - 2200
+    - 2200
+    - 2200
+    - 2200
+  pmconversion: 1
+
+
+OC:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_OC.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_OC.v1_3.RRTMG.nc4
+  tracers:
+    - OCPHOBIC
+    - OCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+BC:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BC.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BC.v1_3.RRTMG.nc4
+  tracers:
+    - BCPHOBIC
+    - BCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
+
+SU:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_3.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_3.RRTMG.nc4
+  tracers:
+    - SO4
+  shapefactor: 1
+  rhod:
+    - 1700
+  pmconversion: 1.3756
+

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -92,17 +92,17 @@ BC:
     - 1800
   pmconversion: 1
 
-#BR:
-#  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_5.nc4
-#  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_5.RRTMG.nc4
-#  tracers:
-#    - BRCPHOBIC
-#    - BRCPHILIC
-#  shapefactor: 1
-#  rhod:
-#    - 1800
-#    - 1800
-#  pmconversion: 1
+BR:
+  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_5.nc4
+  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_5.RRTMG.nc4
+  tracers:
+    - BRCPHOBIC
+    - BRCPHILIC
+  shapefactor: 1
+  rhod:
+    - 1800
+    - 1800
+  pmconversion: 1
 
 SU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_3.nc4
@@ -119,13 +119,13 @@ NI:
   bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
   tracers:
     - NO3AN1
-#    - NO3AN2
-#    - NO3AN3
+    - NO3AN2
+    - NO3AN3
   shapefactor: 1
   rhod:
     - 1725
-#    - 2200
-#    - 2650
+    - 2200
+    - 2650
   pmconversion: 1
 
 """
@@ -523,6 +523,8 @@ class G2GAOP(object):
     
         PMsize: float, particle diameter threshold in microns. If None, the total PM is calculated.
 
+	Please see m2_pm25.yaml and g2g_pm25.yaml for example yaml configurations.
+
         """
 
         # All species on file or a subset
@@ -625,8 +627,6 @@ class G2GAOP(object):
                 rhow = 997.0  # density of water at 25 C and 1 atm in kg m-3
                 growthfactor= 1 + (((np.squeeze(rEff_) / np.squeeze(rEff_zero))**3 - 1) * (rhow / rhod_))
                 #Compute PM
-                #The PM conversion is 1 for all species except sulfate. A factor of 1.3756 is needed 
-                #to convert the sulfate ion to ammonium sulfate.
                 pm_ = q_conc * growthfactor * fPM * self.mieTable[s]['pmconversion']
                 pm += pm_
 

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -29,6 +29,8 @@ G2G_MieMap = """
 #               GMAO Office Note No. 22 (Version 1.1): 
 #               Collow, A., V. Buchard, M. Chin, P. Colarco, A. Darmenov, and A. da Silva, 2023. 
 #               Supplemental Documentation for GEOS Aerosol Products
+#  pmconversion: additional factor for unaccounted aerosol species. was implemented to allow for sulfate to represent missing ammonium in MERRA-2.
+#              pmconversion = 1.3756 for SU for MERRA-2, otherwise = 1
 
 DU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_DU.v15_3.nc4
@@ -112,7 +114,7 @@ SU:
   shapefactor: 1
   rhod:
     - 1700
-  pmconversion: 1.3756
+  pmconversion: 1 
 
 NI:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -46,6 +46,7 @@ DU:
     - 2650
     - 2650
     - 2650
+  pmconversion: 1
 
 
 SS:
@@ -64,6 +65,7 @@ SS:
     - 2200
     - 2200
     - 2200
+  pmconversion: 1
 
 
 OC:
@@ -76,6 +78,7 @@ OC:
   rhod:
     - 1800
     - 1800
+  pmconversion: 1
 
 BC:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BC.v1_3.nc4
@@ -87,17 +90,19 @@ BC:
   rhod:
     - 1800
     - 1800
+  pmconversion: 1
 
-BR:
-  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_5.nc4
-  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_5.RRTMG.nc4
-  tracers:
-    - BRCPHOBIC
-    - BRCPHILIC
-  shapefactor: 1
-  rhod:
-    - 1800
-    - 1800
+#BR:
+#  monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_5.nc4
+#  bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_5.RRTMG.nc4
+#  tracers:
+#    - BRCPHOBIC
+#    - BRCPHILIC
+#  shapefactor: 1
+#  rhod:
+#    - 1800
+#    - 1800
+#  pmconversion: 1
 
 SU:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_SU.v1_3.nc4
@@ -107,19 +112,21 @@ SU:
   shapefactor: 1
   rhod:
     - 1700
+  pmconversion: 1.3756
 
 NI:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4
   bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
   tracers:
     - NO3AN1
-    - NO3AN2
-    - NO3AN3
+#    - NO3AN2
+#    - NO3AN3
   shapefactor: 1
   rhod:
     - 1725
-    - 2200
-    - 2650
+#    - 2200
+#    - 2650
+  pmconversion: 1
 
 """
 
@@ -618,7 +625,9 @@ class G2GAOP(object):
                 rhow = 997.0  # density of water at 25 C and 1 atm in kg m-3
                 growthfactor= 1 + (((np.squeeze(rEff_) / np.squeeze(rEff_zero))**3 - 1) * (rhow / rhod_))
                 #Compute PM
-                pm_ = q_conc * growthfactor * fPM
+                #The PM conversion is 1 for all species except sulfate. A factor of 1.3756 is needed 
+                #to convert the sulfate ion to ammonium sulfate.
+                pm_ = q_conc * growthfactor * fPM * self.mieTable[s]['pmconversion']
                 pm += pm_
 
                 bin += 1


### PR DESCRIPTION
This PR includes changes to aop.py and the introduction of three example yaml files in a new config directory for the calculation of particulate matter in different GEOS systems. MERRA-2 requires a conversion of the sulfate ion to ammonium sulfate while all systems that include nitrate can use ammonium directly. The yaml files also reflect that the available species and optics files have changed over time in GEOS.