### PR TITLE
Update to ESMA_env v4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-# [Unreleased] 2024-08-19 Modified by A.Collow
-### Added
-- lite_install script for systems not supported by GMAO (e.g. external collaborators)
-
-### Changed
-- Updated README to document lite_install
-
-### Fixed
--missing conversion from the sulfate ion to ammonium sulfate
-
-# [Unreleased] 2024-04-19 Modified by A.Collow
+# [Unreleased]
 
 ### Added 
+- lite_install script for systems not supported by GMAO (e.g. external collaborators)
 - pm class to aop.py - with some additional comments
 - G2GAOP can now take a string as the config file variable input
 - add a function to sampler that can append a vertical coordinate to a sampled dataset
@@ -24,18 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 
 
+- Updated README to document lite_install
+- Update `components.yaml` to match that of AeroApps
+  - Mainly for newer ESMA_env that allows building on RHEL8 GMAO
+    machines (e.g., calculon)
+  - Use postfix-@ for subrepos to match AeroApps
+
 ### Fixed 
--
+- missing conversion from the sulfate ion to ammonium sulfate
 - aop.py *getAOPrt* phase function now being correctly normalized 
   by total scattering
-
 - aop.py - protect against divide by zero in getAOPrt and getAOPext when doing calculation for an individual species
-
 - aop.py - remove dependency on having 'DU' as a species in your yaml optics table definition
 - calipso_l1p5.py - took out extinction from list of variables.  L1.5 files don't have this
 - calipso_l2.py - use variable attributes to mask missing data, read the altitude coordinate from metadata
-- constants.py - fix typo in units of gravity
-and calipso_l2 scripts 
+- constants.py - fix typo in units of gravity and calipso_l2 scripts 
+
 ### Removed 
 
 # [v1.1.0] 2024-03-20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GMAOpyobs
-  VERSION 1.0.2
+  VERSION 1.1.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Enforce out of source directory builds

--- a/components.yaml
+++ b/components.yaml
@@ -3,19 +3,19 @@ GMAOpyobs:
   develop: develop
 
 env:
-  local: ./@env
+  local: ./env@
   remote: ../ESMA_env.git
-  tag: v3.13.0
+  tag: v4.8.2
   develop: main
 
 cmake:
-  local: ./@cmake
+  local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.14.0-alpha
+  tag: v3.28.0
   develop: develop
 
 ecbuild:
-  local: ./@cmake/@ecbuild
+  local: ./cmake@/ecbuild@
   remote: ../ecbuild.git
-  tag: geos/v1.2.0
+  tag: geos/v1.3.0
 


### PR DESCRIPTION
This PR updates the `components.yaml` to match that of AeroApps where updates to ESMA_env were needed to support RHEL8 GMAO machines (e.g., calculon) (see https://github.com/GEOS-ESM/AeroApps/pull/62)

Also, to match the style of AeroApps, we move to postfix-@ style in mepo (will make comparing and updating `components.yaml` easier in the future)

Again, not sure if zero-diff or not with these changes. OS itself can change answers.