### PR TITLE
Add ability to not allow f2py code to build for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Mainly for newer ESMA_env that allows building on RHEL8 GMAO
     machines (e.g., calculon)
   - Use postfix-@ for subrepos to match AeroApps
+- Allow ability to not build f2py code for CI purposes
 
 ### Fixed 
 - missing conversion from the sulfate ion to ammonium sulfate

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Run the cmake_it script
 ```
 
 #### Multi-step build
+
 Follow these instructions for managing multi-version builds, or custom builds.
 
 ##### Create build directory
+
 We currently do not allow in-source builds of GEOSgcm. So we must make a directory:
 ```
 mkdir build
@@ -86,27 +88,35 @@ mkdir build
 The advantages of this is that you can build both a Debug and Release version with the same clone if desired.
 
 ##### Run cmake
+
 CMake generates the Makefiles needed to build the model.
 ```
-cd build
-cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=ifort --install-prefix=$(pwd)/install
 ```
-This will install to a directory parallel to your `build` directory. If you prefer to install elsewhere change the path in:
-```
--DCMAKE_INSTALL_PREFIX=<path>
-```
-and CMake will install there.
+This will install to a directory `install` parallel to your `build` directory. If you prefer to install elsewhere change
+the `--install-prefix` option  and CMake will install there.
 
 ##### Building with debugging flags
+
 To build with debugging flags add:
 ```
 -DCMAKE_BUILD_TYPE=Debug
 ```
 to the cmake line.
 
-### Compile and install with make
+##### Disabling f2py
+
+To disable building of f2py modules add:
 ```
-make -j6 install
+-DUSE_F2PY=OFF
+```
+NOTE: This is really only used for systems that do not (yet) support f2py like those used in CI. As the f2py
+code in GMAOpyobs is essential for the code to work, this should not be used in general.
+
+### Compile and install with make
+
+```
+cmake --build build --target install -j 6
 ```
 
 ## How to build GMAOpyobs on other systems

--- a/src/f2py/CMakeLists.txt
+++ b/src/f2py/CMakeLists.txt
@@ -8,6 +8,7 @@ esma_set_this ( OVERRIDE GMAOpyobs )
 
 # cmake requirements
 # ------------------
+if (USE_F2PY)
   find_package(F2PY3 REQUIRED)
 
 
@@ -58,3 +59,4 @@ esma_set_this ( OVERRIDE GMAOpyobs )
    )  
    add_dependencies(sgp4_ ${this})
 
+endif (USE_F2PY)

--- a/src/f2py/CMakeLists.txt
+++ b/src/f2py/CMakeLists.txt
@@ -8,6 +8,9 @@ esma_set_this ( OVERRIDE GMAOpyobs )
 
 # cmake requirements
 # ------------------
+# NOTE: For CI purposes, f2py is hard to support. Until
+#       a solution can be found, we add a flag to allow
+#       the user to disable f2py in these circumstances
 if (USE_F2PY)
   find_package(F2PY3 REQUIRED)
 


### PR DESCRIPTION
This is almost antithetical to GMAOpyobs but I'm currently having issues trying to get CI to support `f2py`. And GMAOpyobs has no way for me to say "for CI purposes, don't do `f2py`"

What this PR does is allow one to set a flag to turn off `f2py`. Obviously, this is not the default (default is `ON`) but for CI, I can avoid f2py for now.

NOTE: I might also need a v1.0.6.1 for GEOSadas CI purposes...