### PR TITLE
trajectory sampler now parses list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased] - yyyy-mm-dd
 
 ### Fixed
+- Added list parsing for variables in trajectory sampler
 ### Added
 - MPL reader and plot curtain 
 - calculation of total backscatter coefficient in aop.py

--- a/src/pyobs/sampler.py
+++ b/src/pyobs/sampler.py
@@ -6,7 +6,7 @@
 
 import os
 
-import numpy  as np 
+import numpy  as np
 import xarray as xr
 import pandas as pd
 
@@ -52,7 +52,7 @@ class STATION(object):
         """
 
         self.verb = verbose
-        
+
         # If dataset is an xarray dataset we are good to go
         # -------------------------------------------------
         if isinstance(dataset,xr.Dataset):
@@ -72,7 +72,7 @@ class STATION(object):
 
         else:
             raise SamplerError("Invalid dataset specification.")
-            
+
         # Save coordinates
         # ----------------
         self.stations = xr.DataArray(stations, dims='station')
@@ -82,7 +82,7 @@ class STATION(object):
         # TO DO: when using xESMF for regridding, pre-compute transforms here
         # -------------------------------------------------------------------
 
-        
+
     #--
     def sample(self,Variables=None,method='linear'):
         """
@@ -129,7 +129,7 @@ class TRAJECTORY(object):
         time_range = times.min(), times.max()
         if isinstance(time_range[0],np.datetime64):
             time_range = pd.to_datetime(time_range)
-        
+
         # If dataset is an xarray dataset we are good to go
         # -------------------------------------------------
         if isinstance(dataset,xr.Dataset):
@@ -195,7 +195,7 @@ class TLETRAJ(TRAJECTORY):
         """
 
         from .tle import TLE
-        
+
         # Generate coordinates
         # --------------------
         times, lons, lats = TLE(tleFile).getSubpoint(t1,t2,dt)
@@ -203,7 +203,7 @@ class TLETRAJ(TRAJECTORY):
         # Initialize base class
         # ---------------------
         super().__init__(times, lons, lats, *args, **kwargs)
-        
+
 
 class WPTRAJ(TRAJECTORY):
 
@@ -221,16 +221,16 @@ class WPTRAJ(TRAJECTORY):
 
         # Initialize base class
         # ---------------------
-        times, lons, lats = traj.index.values, traj['lon'].values, traj['lat'].values 
+        times, lons, lats = traj.index.values, traj['lon'].values, traj['lat'].values
         super().__init__(times, lons, lats, *args, **kwargs)
-        
+
 
 #......................................  Station Sampler CLI ..........................................
 
 def CLI_stnSampler():
-    
+
     """
-    Parses command line and write files with resulting station sampling results. 
+    Parses command line and write files with resulting station sampling results.
     """
 
     from optparse        import OptionParser
@@ -238,7 +238,7 @@ def CLI_stnSampler():
     format = 'NETCDF4'
     outFile = 'stn_sampler.nc'
     method = 'linear'
-    
+
 #   Parse command line options
 #   --------------------------
     parser = OptionParser(usage="Usage: %prog [OPTIONS] stnFile.csv inDataset [iso_t1 iso_t2]\n"+\
@@ -258,7 +258,7 @@ def CLI_stnSampler():
 
     parser.add_option("-V", "--vars", dest="Vars", default=None,
               help="Variables to sample, comma delimited (default=All)")
-    
+
     parser.add_option("-f", "--format", dest="format", default=format,
               help="Output file format: one of NETCDF4, NETCDF4_CLASSIC, NETCDF3_64BIT,NETCDF3_CLASSIC (default=%s)"%format )
 
@@ -269,9 +269,9 @@ def CLI_stnSampler():
     parser.add_option("-v", "--verbose",
                       action="store_true", dest="verbose",
                       help="Verbose mode.")
-    
+
     (options, args) = parser.parse_args()
-    
+
     if len(args) == 4 :
         stnFile, dataset, iso_t1, iso_t2 = args
         t1, t2 = (isoparser(iso_t1), isoparser(iso_t2))
@@ -286,7 +286,7 @@ def CLI_stnSampler():
 
     if options.format not in ["NETCDF4","NETCDF4_CLASSIC","NETCDF3_64BIT","NETCDF3_CLASSIC"]:
         raise ValueError('Invalid format <%s>'%options.format)
-        
+
     # Read coordinates from CSV file
     # ------------------------------
     df = pd.read_csv(stnFile, index_col=0)
@@ -302,7 +302,7 @@ def CLI_stnSampler():
         print(ds)
         print('- Writing',options.outFile)
 
-        
+
     # Write out netcdf file
     # ---------------------
     ds.to_netcdf(options.outFile,format=options.format)
@@ -336,7 +336,7 @@ def _getTrackHSRL(hsrlFile,dt_secs=60):
     h = HSRL(hsrlFile,Nav_only=True)
     lon, lat, tyme = h.lon[:].ravel(), h.lat[:].ravel(), h.tyme[:].ravel()
     if dt_secs > 0:
-        dt = tyme[1] - tyme[0] 
+        dt = tyme[1] - tyme[0]
         idt = int(dt_secs/dt.total_seconds()+0.5)
         return (lon[::idt], lat[::idt], tyme[::idt])
     else:
@@ -349,11 +349,11 @@ def _getTrackCSV(csvFile):
     """
     df = pd.read_csv(csvFile, index_col=0)
     lon, lat, time = (df['lon'].values,df['lat'].values,pd.to_datetime(df.index).values)
-    return (lon,lat,time)   
+    return (lon,lat,time)
 
-        
+
     return ( np.array(lon), np.array(lat), np.array(tyme) )
-    
+
 def _getTrackNPZ(npzFile):
     """
     Get trajectory from a NPZ with (lon,lat,time) coordinates.
@@ -437,9 +437,9 @@ def addVertCoord(aer):
 
 #................................................................................
 def CLI_trjSampler():
-    
+
     """
-    Parses command line and write files with resulting trajectory sampling results. 
+    Parses command line and write files with resulting trajectory sampling results.
     """
 
     from .waypoint import WAYPOINT
@@ -483,7 +483,7 @@ def CLI_trjSampler():
 
     parser.add_option("-V", "--vars", dest="Vars", default=None,
               help="Variables to sample, comma delimited (default=All)")
-    
+
     parser.add_option("-t", "--trajectory", dest="traj", default=None,
                       help="Trajectory file format: one of tle, ict, csv, wp, npz (default=trjFile extension except for wp)" )
 
@@ -500,7 +500,7 @@ def CLI_trjSampler():
                       help="Verbose mode.")
 
     (options, args) = parser.parse_args()
-    
+
     if options.traj == 'WP':
         trjFile, dataset = args[0:2]
         TakeOff = args[2:]
@@ -518,7 +518,10 @@ def CLI_trjSampler():
         name, ext = os.path.splitext(trjFile)
         options.traj = ext[1:]
     options.traj = options.traj.upper()
-        
+
+    if options.Vars is not None:
+        options.Vars = options.Vars.split(',')
+
     # Create consistent file name extension
     # -------------------------------------
     name, ext = os.path.splitext(options.outFile)
@@ -574,13 +577,13 @@ def CLI_trjSampler():
     # All else
     # --------
     else:
-        
+
         trj = TRAJECTORY(time,lon,lat,dataset,verbose=options.verbose)
         ds = trj.sample(Variables=options.Vars,method=method)
         if options.verbose:
             #print(ds)
             print('- Writing',outFile,'from',trjFile,'(%s)'%options.traj)
-        
+
         # Write out netcdf file
         # ---------------------
         ds.to_netcdf(options.outFile,format=options.format)
@@ -590,7 +593,7 @@ def CLI_trjSampler():
 if __name__ == "__main__":
 
       pass
-  
+
 def test_tle():
 
       tleFile = '/Users/adasilva/data/tle/terra/terra.2023-04-15.tle'
@@ -600,13 +603,13 @@ def test_tle():
       t1 = datetime(2023,4,15,0,0,0)
       t2 = datetime(2023,4,15,6,0,0)
       dt = timedelta(minutes=1)
-    
+
       wt = TLETRAJ(tleFile,t1,t2,dt,aer_Nx,verbose=True)
 
       ds = wt.sample()
 
       return ds
-  
+
 def test_waypoint():
 
       wpFile = '/Users/adasilva/data/wp/phillipines_waypoints.csv'
@@ -615,17 +618,17 @@ def test_waypoint():
 
       takeoff = '2023-04-15T08:00:00'       # either string or datetime
       takeoff = datetime(2023,4,15,8,0,0)
-      
+
       wt = WPTRAJ(wpFile,'DC8',takeoff,aer_Nx,verbose=True)
-      
+
       ds = wt.sample()
 
       return ds
-  
+
 def test_trajecgory():
-    
+
       from datetime import datetime
-    
+
       merra2_dn = '/Users/adasilva/data/merra2/Y2023/M04/'
       aer_Nx = merra2_dn + '/MERRA2.tavg1_2d_aer_Nx.????????.nc4'
 
@@ -634,14 +637,14 @@ def test_trajecgory():
       c = xr.open_dataset(traj_fn)
 
       times, lons, lats = c['time'].values, c['lon'].values, c['lat'].values
-      
+
       traj = TRAJECTORY(times, lons, lats, aer_Nx)
       ds = traj.sample(Variables=['DUEXTTAU', 'DUCMASS'])
 
       print(ds)
-      
+
 def test_stations():
-      
+
       fluxnet_fn = '/Users/adasilva/data/brdf/fluxnet_stations.csv'
 
       stations = pd.read_csv('/Users/adasilva/data/brdf/fluxnet_stations.csv',
@@ -669,4 +672,4 @@ def test_stations():
       print(ds2)
 
 
-        
+


### PR DESCRIPTION
Quick fix for missing handling of a list in the trajectory sampler code. Very simple issue: the trajectory sampler says that it can take in a list of variables to be sampled with the `-V` option but the `option.Vars` variable is never parsed as a list so the entire list of variables is interpreted as one long variable.

I fixed this by copying the (2-line) logic from the station sampler that handles specified variables at line 522 in `src/pyobs/sampler.py`:

```
if options.Vars is not None:
    options.Vars = options.Vars.split(',')
```