### PR TITLE
Feature/pcastell/ams trans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xrctl supports providing a list of control files
 - parse time in MPL reader to return datetimes
 - sampler notebook that uses station sampler at an MPL
+- add option for vacuum aerodynamic size cutoff
 ### Changed
 - add auto chunking to TRAJECTORY and STATION. This enables dask
 - preload some key variables in aop.py so you don't hit dask repeatedly in for loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added list parsing for variables in trajectory sampler
 - fixed byte string bug in aeronet.py
+- use a local copy of RH in aop calculator.  otherwise it overwrites when fixRH is used
 ### Added
 - MPL reader and plot curtain 
 - calculation of total backscatter coefficient in aop.py

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -648,7 +648,7 @@ class G2GAOP(object):
         # repeatedly looping through  AOP calculations
         # -------------------------------------------------------
         a['AIRDENS'].load()
-        a['RH'].load().copy()
+        a['RH'].load()
 
         # Determine PM Threshold
         # -------------------------------
@@ -664,7 +664,7 @@ class G2GAOP(object):
         except:
             dp = a['delp'].load()
 
-        rh = a['RH']
+        rh = a['RH'].copy()
 
         # Check FIXRH option
         # --------------------------

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -616,7 +616,7 @@ class G2GAOP(object):
 
         raise AOPError("not implemented yet")
 
-    def getPM(self,Species=None,pmsize=None,fixrh=None,aerodynamic=False):
+    def getPM(self,Species=None,pmsize=None,fixrh=None,aerodynamic=False,vacuum_aerodynamic=False):
         """
         Returns an xarray Dataset with total aerosol mass smaller than the prescribed size.
 
@@ -625,7 +625,13 @@ class G2GAOP(object):
     
         PMsize: float, particle diameter threshold in microns. If None, the total PM is calculated.
 
-	Please see m2_pm25.yaml and g2g_pm25.yaml for example yaml configurations.
+    	Please see m2_pm25.yaml and g2g_pm25.yaml for example yaml configurations.
+
+        aerodynamic = use the continuum aerodynamic radius as the basis for size cutoff. 
+                      typically used for comparisons to surface sites
+        vacuum_aerodynamic = use the vacuum aerodynamic radius as the basis for size cutoff.
+                      used for comparison to aircraft AMS observations.
+        see deCarlo 2004 (DOI: 10.1080/027868290903907) for definitions of aerodynamic radius 
 
         """
 
@@ -712,7 +718,11 @@ class G2GAOP(object):
                 if aerodynamic:
                     # convert rhod from kg m-3 to g cm-3
                     rLow_ = rLow_ * np.sqrt((rhod_/1000)/self.mieTable[s]['shapefactor']) 
-                    rUp_ = rUp_ * np.sqrt((rhod_/1000)/self.mieTable[s]['shapefactor']) 
+                    rUp_ = rUp_ * np.sqrt((rhod_/1000)/self.mieTable[s]['shapefactor'])
+                elif vacuum_aerodynamic:
+                    # convert rhod from kg m-3 to g cm-3
+                    rLow_ = rLow_ * (rhod_/1000)/self.mieTable[s]['shapefactor']
+                    rUp_ = rUp_ * (rhod_/1000)/self.mieTable[s]['shapefactor']
 
                 # Find fraction of bin that is below the threshhold
                 if rPM is None:

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -266,7 +266,7 @@ class G2GAOP(object):
         # -------------------------------------
         rhodz = dp / GRAV
         dz = rhodz / a['AIRDENS']       # column thickness
-        rh = a['RH']
+        rh = a['RH'].copy()
 
 
         # Check FIXRH option
@@ -420,7 +420,7 @@ class G2GAOP(object):
         except:
             dp = a['delp'].load()
         airdens = a['AIRDENS'].load()
-        rh = a['RH'].load()
+        rh = a['RH'].load().copy()
         
         # Check FIXRH option
         # --------------------------
@@ -648,7 +648,7 @@ class G2GAOP(object):
         # repeatedly looping through  AOP calculations
         # -------------------------------------------------------
         a['AIRDENS'].load()
-        a['RH'].load()
+        a['RH'].load().copy()
 
         # Determine PM Threshold
         # -------------------------------


### PR DESCRIPTION
- adds an option to use vacuum aerodynamic diameter as a cut off in getPM.  AMS uses this
- use a local copy of RH in aop.py calculation. otherwise you overwrite RH when using the fixRH option