### PR TITLE
Fixes #103. Fix misspelled ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed some misspelled `ValueError` exceptions
+
 ### Added
 - now getAOPrt returns the phase matrix as detault instead of pmom (the pmatrix expansion)
 ### Changed

--- a/src/pyobs/goesx.py
+++ b/src/pyobs/goesx.py
@@ -339,7 +339,7 @@ class GOESX_CLRSKY(object):
         from pyods import ODS # must be inported before pyhdf
   
         if self.syn_time == None:
-            raise ValuError("synoptic time missing, cannot write ODS")
+            raise ValueError("synoptic time missing, cannot write ODS")
             
         # Stop here is no good obs available
         # ----------------------------------

--- a/src/pyobs/mxd04.py
+++ b/src/pyobs/mxd04.py
@@ -435,7 +435,7 @@ class MxD04_L2(object):
         """
         
         if self.syn_time == None:
-            raise ValuError("synoptic time missing, cannot write ODS")
+            raise ValueError("synoptic time missing, cannot write ODS")
             
         # Stop here is no good obs available
         # ----------------------------------

--- a/src/pyobs/vx04.py
+++ b/src/pyobs/vx04.py
@@ -729,7 +729,7 @@ class Vx04_L2(object):
         """
         
         if self.syn_time == None:
-            raise ValuError("synoptic time missing, cannot write ODS")
+            raise ValueError("synoptic time missing, cannot write ODS")
             
         # Stop here if no good obs available
         # ----------------------------------


### PR DESCRIPTION
Closes #103 

This fixes the misspelled `ValuError`

Technically, this should probably be a hotfix on `main` but since this has been here for a long time, we must never hit it.