### PR TITLE
Bugfix/pcastell/aop ang and release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fixed error when duplicate variables occur in an icartt file. ICARTT now reads the first instance of the duplicate variable.
-
 ### Added
-
-- add KX for lunar AERONET obs
-- add KX for NOAA-20 AOD obs
 
 ### Changed
 
 ### Removed
 
 ### Deprecated
+
+# [v1.4.0] - 2025-09-25
+
+### Fixed
+
+- fixed error when duplicate variables occur in an icartt file. ICARTT now reads the first instance of the duplicate variable.
+- fixed bug in aop.py that broke if you used v1.X.X optics tables (that don't include pmatrix)
+
+### Added
+
+- add KX for lunar AERONET obs
+- add KX for NOAA-20 and NOAA-21 AOD obs
+
 
 # [v1.3.0] - 2025-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fixed error when duplicate variables occur in an icartt file. ICARTT now reads the first instance of the duplicate variable.
 - fixed bug in aop.py that broke if you used v1.X.X optics tables (that don't include pmatrix)
+- fixed bug in aop.py that broke if you had lowercase DELP in your model files
 
 ### Added
 

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -272,16 +272,15 @@ class G2GAOP(object):
         # pre-load RH, AIRDENS, and DELP so you don't hit dask
         # repeatedly looping through  AOP calculations
         # -------------------------------------------------------
-        a['DELP'].load()
         a['AIRDENS'].load()
         a['RH'].load()
 
         # GEOS files can be inconsistent when it comes to case
         # ----------------------------------------------------
         try:
-            dp = a['DELP']
+            dp = a['DELP'].load()
         except:
-            dp = a['delp']
+            dp = a['delp'].load()
 
         # Handy arrays for extensive properties
         # -------------------------------------

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -211,9 +211,14 @@ class G2GAOP(object):
                self.p, self.m, self.ang = None, None, None
                print('Warning: cannot handle variable size phase matrix for PMOM or PMATRIX')
                break
-           if self.vector and dims_['ang'] != dims['ang']:
-               self.ang = None # variable angular resolution phase matrix not implemented
-               print('Warning: cannot handle variable angular resolution phase matrix for PMATRIX')
+           if self.vector:
+               if 'ang' not in dims:  # keep back compatibility with v1 files that don't have PMATRIX
+                   self.ang = None 
+                   print('Warning: phase matrix not implemented')
+               elif dims_['ang'] != dims['ang']:
+                   self.ang = None # variable angular resolution phase matrix not implemented
+                   print('Warning: cannot handle variable angular resolution phase matrix for PMATRIX')
+                   break
                                
            self.p = max(self.p,dims_['p']) # max number of entries in phase matrix
            self.m = max(self.m,dims_['m']) # max number of moments in phase matrix

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -222,7 +222,8 @@ class G2GAOP(object):
                                
            self.p = max(self.p,dims_['p']) # max number of entries in phase matrix
            self.m = max(self.m,dims_['m']) # max number of moments in phase matrix
-           self.ang = max(self.ang,dims_['ang']) # number of angles in phase matrix
+           if self.ang is not None:
+               self.ang = max(self.ang,dims_['ang']) # number of angles in phase matrix
         
     def getAOPrt(self,Species=None,wavelength=None,vector=False,
                  fixrh=None,m=None,dopmatrix=True,dopmom=False,

--- a/src/pyobs/vx04.py
+++ b/src/pyobs/vx04.py
@@ -171,6 +171,11 @@ KX = dict ( SNPP_DT_OCEAN = 337,
             NOAA20_DB_OCEAN  = 339,
             NOAA20_DB_DEEP   = 340,
             NOAA20_DB_LAND  = 338,
+            NOAA21_DT_OCEAN = 348,
+            NOAA21_DT_LAND  = 347,
+            NOAA21_DB_OCEAN  = 345,
+            NOAA21_DB_DEEP   = 346,
+            NOAA21_DB_LAND  = 344,           
           )
 
 KT = dict ( AOD = 45, )
@@ -185,6 +190,11 @@ IDENT = dict ( SNPP_DT_OCEAN = 'vsnppdto',
                NOAA20_DB_OCEAN  = 'vnoaa20dbo',
                NOAA20_DB_DEEP  = 'vnoaa20dbd',
                NOAA20_DB_LAND  = 'vnoaa20dbl',
+               NOAA21_DT_OCEAN = 'vnoaa20dto',
+               NOAA21_DT_LAND  = 'vnoaa20dtl',
+               NOAA21_DB_OCEAN  = 'vnoaa20dbo',
+               NOAA21_DB_DEEP  = 'vnoaa20dbd',
+               NOAA21_DB_LAND  = 'vnoaa20dbl',
           )
 
 MISSING = 999.999


### PR DESCRIPTION
fixes a bug in aop.py when using v1.x.x optics tables that don't include pmatrix as a variable and therefore don't have an angle dimension