### PR TITLE
Feature/pcastell/improve update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 ### Added
+- add optional explicit bin ordering to aop.py yaml. this allows for calculating AOP's for a single bin, or subset of bins
+
 ### Changed
-### Remoed
+- use xesmf regridder to station sampling. this is more efficient that using xarray native interp
+
+### Removed
 ### Deprecated
 
 # [1.7.0] - yyyy-mm-dd

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -42,6 +42,12 @@ DU:
     - DU003
     - DU004
     - DU005
+  bin:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
   shapefactor: 1.4
   rhod:
     - 2500
@@ -61,6 +67,12 @@ SS:
     - SS003
     - SS004
     - SS005
+  bin:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
   shapefactor: 1
   rhod:
     - 2200
@@ -77,6 +89,9 @@ OC:
   tracers:
     - OCPHOBIC
     - OCPHILIC
+  bin:
+    - 1
+    - 2
   shapefactor: 1
   rhod:
     - 1800
@@ -89,6 +104,9 @@ BC:
   tracers:
     - BCPHOBIC
     - BCPHILIC
+  bin:
+    - 1
+    - 2
   shapefactor: 1
   rhod:
     - 1800
@@ -101,6 +119,9 @@ BR:
   tracers:
     - BRCPHOBIC
     - BRCPHILIC
+  bin:
+    - 1
+    - 2
   shapefactor: 1
   rhod:
     - 1800
@@ -112,6 +133,8 @@ SU:
   bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_SU.v1_3.RRTMG.nc4
   tracers:
     - SO4
+  bin:
+    - 1
   shapefactor: 1
   rhod:
     - 1700
@@ -124,6 +147,10 @@ NI:
     - NO3AN1
     - NO3AN2
     - NO3AN3
+  bin:
+    - 1
+    - 2
+    - 3
   shapefactor: 1
   rhod:
     - 1725
@@ -322,8 +349,11 @@ class G2GAOP(object):
             Tracers = self.mieTable[s]['tracers']
             mie = self.mieTable[s]['mie']
 
-            bin = 1
-            for q in Tracers:
+            bins = self.mieTable[s].get('bin',[])
+            if not bins:
+                bins = list(range(1,len(Tracers)+1))
+            
+            for q,bin in zip(Tracers,bins):
 
                 if self.verbose:
                     print('   -',q)
@@ -356,8 +386,6 @@ class G2GAOP(object):
 
                     g   += sca_ * g_
 
-
-                bin += 1
 
         # Final normalization of SSA and g
         # protect against divide by zero
@@ -497,8 +525,11 @@ class G2GAOP(object):
             Tracers = self.mieTable[s]['tracers']
             mie = self.mieTable[s]['mie']
 
-            bin = 1
-            for q in Tracers:
+            bins = self.mieTable[s].get('bin',[])
+            if not bins:
+                bins = list(range(1,len(Tracers)+1))
+
+            for q,bin in zip(Tracers,bins):
 
                 if self.verbose:
                     print('   -',q)
@@ -521,7 +552,6 @@ class G2GAOP(object):
                 depol1 += (pback11_-pback22_) * sca_
                 depol2 += (pback11_+pback22_) * sca_
 
-                bin += 1
 
         if doaback:
             # Compute Molecular Scattering and Total Attenuated Backscatter Coefficient
@@ -748,8 +778,14 @@ class G2GAOP(object):
             Tracers = self.mieTable[s]['tracers']
             mie = self.mieTable[s]['mie']
 
-            bin = 1
-            for q in Tracers:
+            bins = self.mieTable[s].get('bin',[])
+            if not bins:
+                bins = list(range(1,len(Tracers)+1))
+
+            # Dry aerosol density in kg m-3
+            # rhod is not in all of the standard optics files, and is for now read from the yaml config
+            rhod = self.mieTable[s]['rhod']
+            for q,bin,rhod_ in zip(Tracers,bins,rhod):
 
                 if self.verbose:
                     print('   -',q)
@@ -758,10 +794,7 @@ class G2GAOP(object):
                 # Aerosol mass concentration in kg/m3                
                 q_conc = (a['AIRDENS'] * a[q]).values
   
-                # Dry aerosol density in kg m-3
-                # rhod is not in all of the standard optics files, and is for now read from the yaml config 
                 # rhod_ = mie.getAOP('rhod',  bin, rh, wavelength=wavelength).values
-                rhod_ = self.mieTable[s]['rhod'][bin-1] 
 
                 # Lower and upper bound of the bin's radius converted from meters to microns
                 rLow_ = mie.getBinInfo('rLow', bin)*1000000 
@@ -816,8 +849,6 @@ class G2GAOP(object):
                 waterfactor = 1 - (1./growthfactor)
                 wm += pm_ * waterfactor
 
-                bin += 1
-                
 
         # Get the fraction of the total PM that is water
         # ------------------------------------------------

--- a/src/pyobs/sampler.py
+++ b/src/pyobs/sampler.py
@@ -15,6 +15,7 @@ from dateutil.parser import parse as isoparser
 from glob import glob
 
 from . import xrctl as xc
+import fsspec
 
 os.environ['HDF5_USE_FILE_LOCKING']='FALSE'
 
@@ -60,6 +61,10 @@ class STATION(object):
         if isinstance(dataset,xr.Dataset):
             self.ds = dataset # we are good to go...
 
+        #  if dataset is a parquet referece file
+        elif dataset[-4:] == 'parq':
+            fs = fsspec.filesystem("reference", fo=dataset, remote_protocol='file', lazy=True)
+            self.ds = xr.open_dataset(fs.get_mapper(), engine="zarr", backend_kwargs={"consolidated": False})        
         # If dataset is a list of files...
         # OR GrADS-style ctl
         # OR a glob type of template
@@ -136,7 +141,10 @@ class TRAJECTORY(object):
         # -------------------------------------------------
         if isinstance(dataset,xr.Dataset):
             self.ds = dataset # we are good to go...
-
+        #  if dataset is a parquet referece file
+        elif dataset[-4:] == 'parq':
+            fs = fsspec.filesystem("reference", fo=dataset, remote_protocol='file', lazy=True)
+            self.ds = xr.open_dataset(fs.get_mapper(), engine="zarr", backend_kwargs={"consolidated": False})
         # If dataset is a list of files...
         # OR GrADS-style ctl 
         # OR a glob type of template

--- a/src/pyobs/sampler.py
+++ b/src/pyobs/sampler.py
@@ -17,6 +17,7 @@ from glob import glob
 
 from . import xrctl as xc
 import fsspec
+import dask.distributed
 
 os.environ['HDF5_USE_FILE_LOCKING']='FALSE'
 
@@ -61,8 +62,9 @@ class STATION(object):
         # -------------------------------------------------
         if isinstance(dataset,xr.Dataset):
             self.ds = dataset # we are good to go...
-
-        #  if dataset is a parquet referece file
+        elif isinstance(dataset,dask.distributed.Future):
+            self.ds = xr.open_dataset(dataset, engine="zarr",chunks=chunks, backend_kwargs={"consolidated": False})
+        #  if dataset is a parquet referece file path
         elif dataset[-4:] == 'parq':
             fs = fsspec.filesystem("reference", fo=dataset, remote_protocol='file', lazy=True)
             self.ds = xr.open_dataset(fs.get_mapper(), engine="zarr",chunks=chunks, backend_kwargs={"consolidated": False})        


### PR DESCRIPTION
- add optional explicit bin ordering to aop.py yaml.  this allows for calculating AOP's for a single bin, or subset of  bins
- use xesmf regridder to station sampling.  this is more efficient that using xarray native interp