### PR TITLE
Feature/pcolarco/aop rlow rup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - use xesmf regridder to station sampling. this is more efficient that using xarray native interp
 - changed 'compat' keyword definition in xrctl.py to make more flexible if 'override' is needed
+- changed aop.py and mietable.py code to handle v2.x.x optics tables consistent with how v1.0.0
+  handled
+- changed tracer names in default aop.py configuration to be like current fp
 
 ### Removed
 ### Deprecated

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -797,8 +797,13 @@ class G2GAOP(object):
                 # rhod_ = mie.getAOP('rhod',  bin, rh, wavelength=wavelength).values
 
                 # Lower and upper bound of the bin's radius converted from meters to microns
-                rLow_ = mie.getAOP('rLow', bin, rh, wavelength=None).values*1000000 
-                rUp_  = mie.getAOP('rUp',  bin, rh, wavelength=None).values*1000000 
+                try:
+                    rLow_ = mie.getAOP('rLow', bin, rh, wavelength=None).values*1000000 
+                    rUp_  = mie.getAOP('rUp',  bin, rh, wavelength=None).values*1000000
+                except:
+                    print("rLow and rDry provided at 0% RH only; use v2.x.x tables and later")
+                    rLow_ = mie.getBinInfo('rLow', bin)*1000000
+                    rUp_ = mie.getBinInfo('rUp', bin)*1000000
 
                 # Effective radius at the specified humidity converted from meters to microns
                 rEff_ = mie.getAOP('rEff', bin, rh, wavelength=None).values*1000000 

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -797,8 +797,8 @@ class G2GAOP(object):
                 # rhod_ = mie.getAOP('rhod',  bin, rh, wavelength=wavelength).values
 
                 # Lower and upper bound of the bin's radius converted from meters to microns
-                rLow_ = mie.getBinInfo('rLow', bin)*1000000 
-                rUp_ = mie.getBinInfo('rUp', bin)*1000000 
+                rLow_ = mie.getAOP('rLow', bin, rh, wavelength=None).values*1000000 
+                rUp_  = mie.getAOP('rUp',  bin, rh, wavelength=None).values*1000000 
 
                 # Effective radius at the specified humidity converted from meters to microns
                 rEff_ = mie.getAOP('rEff', bin, rh, wavelength=None).values*1000000 

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -144,9 +144,9 @@ NI:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_NI.v2_5.nc4
   bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_NI.v2_5.RRTMG.nc4
   tracers:
-    - NO3AN1
-    - NO3AN2
-    - NO3AN3
+    - NI001
+    - NI002
+    - NI003
   bin:
     - 1
     - 2

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -798,18 +798,26 @@ class G2GAOP(object):
 
                 # Lower and upper bound of the bin's radius converted from meters to microns
                 try:
-                    rLow_ = mie.getAOP('rLow', bin, rh, wavelength=None).values*1000000 
-                    rUp_  = mie.getAOP('rUp',  bin, rh, wavelength=None).values*1000000
+                    rhdry = rh.copy()
+                    rhdry[:] = 0.0
+                    rLow_ = mie.getAOP('rLow', bin, rhdry, wavelength=None).values*1000000 
+                    rUp_  = mie.getAOP('rUp',  bin, rhdry, wavelength=None).values*1000000
+                    # Force recast of rLow_ and rUp_ to be dry value (scalar) for compatibility with old code
+                    rLow_ = np.squeeze(rLow_[0,0])
+                    rUp_  = np.squeeze(rUp_[0,0])
                 except:
                     print("rLow and rDry provided at 0% RH only; use v2.x.x tables and later")
                     rLow_ = mie.getBinInfo('rLow', bin)*1000000
                     rUp_ = mie.getBinInfo('rUp', bin)*1000000
-
+                    
                 # Effective radius at the specified humidity converted from meters to microns
                 rEff_ = mie.getAOP('rEff', bin, rh, wavelength=None).values*1000000 
 
                 # Effective radius at a relative humidity of 0% converted from meters to microns
-                rEff_zero = rEff_[0]
+                rhdry = rh.copy()
+                rhdry[:] = 0.0
+                rEff_zero = mie.getAOP('rEff', bin, rhdry, wavelength=None).values*1000000 
+                rEff_zero = np.squeeze(rEff_zero[0,0])
 
                 # If necessary, compute the aerodynamic particle radius
                 # shape factor accounts for changes in the particle's dragging coefficient (see https://doi.org/10.1029/2002JD002485 for more info)

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -809,7 +809,8 @@ class G2GAOP(object):
                 rEff_ = mie.getAOP('rEff', bin, rh, wavelength=None).values*1000000 
 
                 # Effective radius at a relative humidity of 0% converted from meters to microns
-                rEff_zero = mie.getBinInfo('rEffDry', bin)*1000000 
+                rhdry = 0.
+                rEff_zero = mie.getAOP('rEff', bin, rhdry, wavelength=None).values*1000000
 
                 # If necessary, compute the aerodynamic particle radius
                 # shape factor accounts for changes in the particle's dragging coefficient (see https://doi.org/10.1029/2002JD002485 for more info)

--- a/src/pyobs/aop.py
+++ b/src/pyobs/aop.py
@@ -117,8 +117,8 @@ BR:
   monoFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/optics_BRC.v1_5.nc4
   bandFile: ExtData/chemistry/AerosolOptics/v1.0.0/x/opticsBands_BRC.v1_5.RRTMG.nc4
   tracers:
-    - BRCPHOBIC
-    - BRCPHILIC
+    - BRPHOBIC
+    - BRPHILIC
   bin:
     - 1
     - 2
@@ -809,8 +809,7 @@ class G2GAOP(object):
                 rEff_ = mie.getAOP('rEff', bin, rh, wavelength=None).values*1000000 
 
                 # Effective radius at a relative humidity of 0% converted from meters to microns
-                rhdry = 0.
-                rEff_zero = mie.getAOP('rEff', bin, rhdry, wavelength=None).values*1000000
+                rEff_zero = rEff_[0]
 
                 # If necessary, compute the aerodynamic particle radius
                 # shape factor accounts for changes in the particle's dragging coefficient (see https://doi.org/10.1029/2002JD002485 for more info)

--- a/src/pyobs/mietable.py
+++ b/src/pyobs/mietable.py
@@ -288,14 +288,13 @@ if __name__ == "__main__":
     
    # Sample Mie Tables
    # -----------------
-   #dirn   = '/discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/AerosolOptics/v0.0.0/x/'
-   dirn   = '/Users/adasilva/data/ExtData/chemistry/AerosolOptics/v1.0.0/x/'
-   Tables = [dirn + 'optics_DU.v15_5.nc4', dirn + 'optics_OC.v2_3.nc4']
+   dirn   = '/gpfsm/dnb07/projects/p10/gmao_ops/fvInput_nc3/chemistry/AerosolOptics/v2.x.x/x/'
+   dirn2  = '/gpfsm/dnb07/projects/p10/gmao_ops/fvInput_nc3/chemistry/AerosolOptics/v1.0.0/x/'
+   Tables = [dirn + 'optics_DU.v2.1.0.nc4', dirn2+'optics_BC.v1_6.nc4']
 
    # Aerosol state (all species)
    # ---------------------------
-   #aer_Nv = '/css/gmao/geos-it/products/Y2023/M02/D05/GEOS.it.asm.aer_inst_3hr_glo_C180x180x6_v72.GEOS5294.2023-02-05T1200.V01.nc4'
-   aer_Nv = '/Users/adasilva/data/sampled/aer_Nv/CAMP2Ex-GEOS-MODISonly-aer-Nv-P3B_Model_*.nc'
+   aer_Nv = '/home/pcolarco/geos_aerosols/pcolarco/c180R_v11.8.1/holding/inst3d_aer_v/201901/c180R_v11.8.1.inst3d_aer_v.20190101_0000z.nc4'
    aer    = xr.open_mfdataset(aer_Nv)
 
    try:
@@ -309,8 +308,9 @@ if __name__ == "__main__":
    # Sample variable names
    # ---------------------
    Vars = ['tau', 'aot', 'gasym', 'bext', 'bsca', 'ssa', 'bbck', 'rEff','rLow','rUp',
-           'RefIndex', 'pmom', 'pback', 'pback11', 'pback22',
-           'aot_ssa_gasym', 'aot_ssa_pmom']
+           'RefIndex']
+   #, 'pmom', 'pback', 'pback11', 'pback22',
+   #        'aot_ssa_gasym', 'aot_ssa_pmom']
 
    # Loop over Tables
    # ----------------
@@ -321,6 +321,9 @@ if __name__ == "__main__":
        print('Doing',species)
        for v in Vars:
            print('-',v)
-           AOP[species,v] = mie.getAOP(v, 1, rh, wavelength=550, q_mass=q_mass[i])
+           try:
+               AOP[species,v] = mie.getAOP(v, 1, rh, wavelength=550, q_mass=q_mass[i])
+           except:
+               AOP[species,v] = mie.getBinInfo(v, 1)
 
 

--- a/src/pyobs/mietable.py
+++ b/src/pyobs/mietable.py
@@ -12,15 +12,15 @@
       channel          (w) channel number
       wavelengths      (w) wavelengths        [m]
       rh               (r) RH values   [fraction]
-      rLow             (b) Dry lower radius [m]
       rEffDry          (b) Dry Effective radius [m]
-      rUp              (b) Dry upper radius [m]
       p                (p) Non-zero elements of phase matrix
       m                (p) Moments of phase matrix
       ang              (a) number of scattering angles [degrees]
 
     Data Variables:
-      reff             (b,r) effective radius [m]
+      rEff             (b,r) effective radius [m]
+      rLow             (b,r) Dry lower radius [m]
+      rUp              (b,r) Dry upper radius [m]
       bext             (b,w,r) bext values [m2 kg-1]
       bsca             (b,w,r) bsca values [m2 kg-1]
       bbck             (b,w,r) bbck values [m2 kg-1]
@@ -32,7 +32,7 @@
       gf               (b,r) hygroscopic growth factor
       rhop             (b,r) wet particle density [kg m-3]
       rhod             (b,r) dry particle density [kg m-3]
-      vol              (b,r) wet particle volume [m3 kg-1]
+      volume           (b,r) wet particle volume [m3 kg-1]
       area             (b,r) wet particle cross section [m2 kg-1]
       refr             (b,w,r) real part of refractive index
       refi             (b,w,r) imaginary part of refractive index
@@ -60,10 +60,11 @@ import numpy  as np
 
 __VERSION__ = '0.9.0'
 
-supportedAOPs = ['aot',          'ssa',     'gf',      'gasym',   'g',   'growth_factor',
-                 'RefIndex',     'pmom',    'area',    'volume',  'pback11', 'pback22', 'pback',
-                 'rhod',         'rhop',    'rEff',    'bbck',    'tau', 'sca',
-                 'bsca',         'bext',    'refreal', 'refimag', 'pmatrix',
+supportedAOPs = ['aot',          'ssa',     'gf',      'gasym',   'g',       'growth_factor',
+                 'RefIndex',     'pmom',    'area',    'volume',  'pback11', 'pback22',
+                 'pback',        'rhod',    'rhop',    'rEff',    'rLow',    'rUp',
+                 'bbck',         'tau',     'sca',     'bsca',    'bext',
+                 'refreal', 'refimag', 'pmatrix',
                  'p11', 'p12', 'p33', 'p34', 'p22', 'p44',
                  'aot_ssa_pmom',
                  'aot_ssa_gasym' ]
@@ -307,7 +308,7 @@ if __name__ == "__main__":
 
    # Sample variable names
    # ---------------------
-   Vars = ['tau', 'aot', 'gasym', 'bext', 'bsca', 'ssa', 'bbck', 'rEff',
+   Vars = ['tau', 'aot', 'gasym', 'bext', 'bsca', 'ssa', 'bbck', 'rEff','rLow','rUp',
            'RefIndex', 'pmom', 'pback', 'pback11', 'pback22',
            'aot_ssa_gasym', 'aot_ssa_pmom']
 


### PR DESCRIPTION
This implements changes in aop.py and mutable.py to allow using GEOSmie v2.x.x-style tables in a fashion compatible with the older v1.0.0 tables. Also changed the default configuration to use tracer names compatible for current FP (f5430).